### PR TITLE
CreateColorgroupAction merges data from input tokens

### DIFF
--- a/ptero_petri/implementation/petri/actions/base.py
+++ b/ptero_petri/implementation/petri/actions/base.py
@@ -38,4 +38,9 @@ class BarrierActionBase(ActionBase):
 
 
 class BasicActionBase(ActionBase):
-    pass
+    def get_merged_token_data(self, net, active_tokens):
+        result = {}
+        tokens = [net.token(t) for t in active_tokens]
+        for t in tokens:
+            result.update(t.data.value)
+        return result

--- a/ptero_petri/implementation/petri/actions/create_color_group.py
+++ b/ptero_petri/implementation/petri/actions/create_color_group.py
@@ -1,14 +1,13 @@
 from .. import webhooks
-from ...container_utils import head
 from .base import BasicActionBase
 from twisted.internet import defer
 
 
 class CreateColorGroupAction(BasicActionBase):
     def execute(self, net, color_descriptor, active_tokens, service_interfaces):
-        input_token = net.token(head(active_tokens))
+        merged_data = self.get_merged_token_data(net, active_tokens)
 
-        size = int(input_token.data['color_group_size'])
+        size = int(merged_data['color_group_size'])
         new_color_group = net.add_color_group(size=size,
                 parent_color=color_descriptor.color,
                 parent_color_group_idx=color_descriptor.group.idx)


### PR DESCRIPTION
Not merging the input data caused a race condition in cases where there
were multiple input places, but only the token in one of them contained
data for `color_group_size`.
