### PR TITLE
Add purge backend script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jsonschema == 2.4.0
 librabbitmq == 1.6.1
 redis == 2.10.3
 requests == 2.4.3
+-e git+https://github.com/genome/ptero-common.git@v0.1.0#egg=ptero_common

--- a/scripts/purge-backends
+++ b/scripts/purge-backends
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+from ptero_common.janitors.redis_janitor import RedisJanitor
+from ptero_common.janitors.rabbitmq_janitor import RabbitMQJanitor
+from ptero_common.janitors import perform_cleanup
+import os
+
+
+def janitor_factory():
+    janitors = []
+
+    janitors.append(RabbitMQJanitor(os.environ['CELERY_BROKER_URL']))
+    janitors.append(RedisJanitor(url=os.environ['CELERY_RESULT_BACKEND']))
+
+    janitors.append(RedisJanitor(url='redis://%s:%s' % (
+        os.environ['PTERO_PETRI_REDIS_HOST'],
+        os.environ['PTERO_PETRI_REDIS_PORT'])))
+
+    return janitors
+
+
+if __name__ == '__main__':
+    perform_cleanup(janitor_factory=janitor_factory, required_envvars=[
+        'CELERY_BROKER_URL',
+        'CELERY_RESULT_BACKEND',
+        'PTERO_PETRI_REDIS_HOST',
+        'PTERO_PETRI_REDIS_PORT',
+    ])

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,flake8
+envlist = py27
 
 [testenv]
 setenv =
@@ -24,13 +24,11 @@ commands =
     coverage erase
     coverage run {envbindir}/nosetests {posargs}
     coverage combine
+    flake8
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-
-[testenv:flake8]
-deps = flake8
-commands = flake8
+    flake8
 
 [flake8]
 max-line-length = 80


### PR DESCRIPTION
This adds `ptero-common` as a requirement and uses the new `janitors` module there to perform backend cleanup.